### PR TITLE
Small update to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,7 +122,7 @@ RUN if [ "$build_dagmc" = "on" ]; then \
         rm -rf ${DD_INSTALL_DIR}/build ${DD_INSTALL_DIR}/double-down ; \
         # Clone and install DAGMC
         mkdir -p $HOME/DAGMC && cd $HOME/DAGMC ; \
-        git clone --single-branch -b ${DAGMC_TAG} --depth 1 ${DAGMC_REPO} ; \
+        git clone --single-branch -b ${DAGMC_BRANCH} --depth 1 ${DAGMC_REPO} ; \
         mkdir build && cd build ; \
         cmake ../DAGMC -DBUILD_TALLY=ON \
                        -DCMAKE_INSTALL_PREFIX=${DAGMC_INSTALL_DIR} \


### PR DESCRIPTION
- Fix installation issue with `double-down` and `DAGMC`
- Change `DAGMC_TAG='3.2.0` -> `DAGMC_BRANCH='develop'` due to the following error message.
```bash
Scanning dependencies of target pyne_dagmc-shared
[  3%] Building CXX object src/pyne/CMakeFiles/pyne_dagmc-shared.dir/pyne.cpp.o
[  4%] Linking CXX static library libgtest.a
[  4%] Built target gtest
[  5%] Linking CXX shared library libpyne_dagmc.so
[  5%] Built target pyne_dagmc-shared
Removing intermediate container a231848d6485
 ---> 7a48f46e4d47
```
But still, with DAGMC support, I got 
```bash
CMake Error at CMakeLists.txt:50 (find_package):
  Could not find a package configuration file provided by "DAGMC" with any of
  the following names:

    DAGMCConfig.cmake
    dagmc-config.cmake

  Add the installation prefix of "DAGMC" to CMAKE_PREFIX_PATH or set
  "DAGMC_DIR" to a directory containing one of the above files.  If "DAGMC"
  provides a separate development package or SDK, be sure it has been
  installed.
```
I think we need `if` block here for each combination instead of passing `OPENMC_CMAKE_ARGS`. 