### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ ENV LIBMESH_REPO='https://github.com/libMesh/libmesh'
 ENV LIBMESH_INSTALL_DIR=$HOME/LIBMESH
 
 # Creates the arguments for the openmc build command using parameter expansion
-ENV OPENMC_CMAKE_ARGS="-Ddebug=on -Doptimize=on -DHDF5_PREFER_PARALLEL=on -Ddagmc=${build_dagmc} -DCMAKE_PREFIX_PATH=${DAGMC_INSTALL_DIR} -Dlibmesh=${build_libmesh} -DCMAKE_PREFIX_PATH=${LIBMESH_INSTALL_DIR}"
+ENV OPENMC_CMAKE_ARGS="-Ddebug=on -Doptimize=on -DHDF5_PREFER_PARALLEL=on -Ddagmc=${build_dagmc} -Dlibmesh=${build_libmesh} -DCMAKE_PREFIX_PATH='${DAGMC_INSTALL_DIR};${LIBMESH_INSTALL_DIR}'"
 
 # Setup environment variables for Docker image
 ENV CC=/usr/bin/mpicc CXX=/usr/bin/mpicxx \


### PR DESCRIPTION
 When I looked into `CMakeCache.txt` after docker builds with `(DAGMC+libmesh)` integration, I saw it was a typical build. 
```
//Enable support for DAGMC (CAD) geometry
dagmc:BOOL=OFF

//Enable support for libMesh unstructured mesh tallies
libmesh:BOOL=OFF
```
Patrick suggests me to include both DAGMC  and libmesh paths in the same spot `-DCMAKE_PREFIX_PATH='${DAGMC_INSTALL_DIR};${LIBMESH_INSTALL_DIR}'`