### PR TITLE
added py3.9 3.10 3.11 to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           - python-version: 3.9
             omp: n
             mpi: n
-          - python-version: 3.10
+          - python-version: '3.10'
             omp: n
             mpi: n
           - python-version: 3.11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,6 @@ jobs:
           - python-version: '3.10'
             omp: n
             mpi: n
-          - python-version: 3.11
-            omp: n
-            mpi: n
     name: "Python ${{ matrix.python-version }} (omp=${{ matrix.omp }},
       mpi=${{ matrix.mpi }}, dagmc=${{ matrix.dagmc }},
       libmesh=${{ matrix.libmesh }}, event=${{ matrix.event }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,15 @@ jobs:
             python-version: 3.8
             omp: n
             mpi: y
+          - python-version: 3.9
+            omp: n
+            mpi: n
+          - python-version: 3.10
+            omp: n
+            mpi: n
+          - python-version: 3.11
+            omp: n
+            mpi: n
     name: "Python ${{ matrix.python-version }} (omp=${{ matrix.omp }},
       mpi=${{ matrix.mpi }}, dagmc=${{ matrix.dagmc }},
       libmesh=${{ matrix.libmesh }}, event=${{ matrix.event }}

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,8 @@ kwargs = {
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
 
     # Dependencies


### PR DESCRIPTION
From a recent[ user survey](https://openmc.discourse.group/t/user-survey-python-version/2338) it looks like we have a few python 3.9 and 3.10 users. We could add these to the CI.

I would like to add py3.11 as well but it appears to be too new from some of the github actions that we make use of.