### PR TITLE
Removing data_type arg from plotter.py functions

### DIFF
--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -200,7 +200,7 @@ def plot_xs(this, types, divisor_types=None, temperature=294., axis=None,
             ylabel = 'Microscopic Cross Section [b]'
         elif isinstance(this, openmc.Element):
             ylabel = 'Elemental Cross Section [b]'
-        elif isinstance(this, openmc.Material or isinstance(this, openmc.Macroscopic):
+        elif isinstance(this, openmc.Material) or isinstance(this, openmc.Macroscopic):
             ylabel = 'Macroscopic Cross Section [1/cm]'
         else:
             raise TypeError("Invalid type for plotting")

--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -60,8 +60,8 @@ def plot_xs(this, types, divisor_types=None, temperature=294., axis=None,
 
     Parameters
     ----------
-    this : str or openmc.Material
-        Object to source data from
+    this : {str, openmc.Nuclide, openmc.Element, openmc.Macroscopic, openmc.Material}
+        Object to source data from. Nuclides and Elements can be input as a str
     types : Iterable of values of PLOT_TYPES
         The type of cross sections to include in the plot.
     divisor_types : Iterable of values of PLOT_TYPES, optional
@@ -200,7 +200,7 @@ def plot_xs(this, types, divisor_types=None, temperature=294., axis=None,
             ylabel = 'Microscopic Cross Section [b]'
         elif isinstance(this, openmc.Element):
             ylabel = 'Elemental Cross Section [b]'
-        elif isinstance(this, openmc.Material):
+        elif isinstance(this, openmc.Material or isinstance(this, openmc.Macroscopic):
             ylabel = 'Macroscopic Cross Section [1/cm]'
         else:
             raise TypeError("Invalid type for plotting")
@@ -616,8 +616,8 @@ def calculate_mgxs(this, types, orders=None, temperature=294.,
 
     Parameters
     ----------
-    this : str or openmc.Material
-        Object to source data from
+    this : {str, openmc.Nuclide, openmc.Element, openmc.Macroscopic, openmc.Material}
+        Object to source data from. Nuclides and Elements can be input as a str
     types : Iterable of values of PLOT_TYPES_MGXS
         The type of cross sections to calculate
     orders : Iterable of Integral, optional

--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -222,7 +222,7 @@ def calculate_cexs(this, types, temperature=294., sab_name=None,
     Parameters
     ----------
     this : {str, openmc.Nuclide, openmc.Element, openmc.Material}
-        Object to source data from
+        Object to source data from. Nuclides and Elements can be input as a str
     types : Iterable of values of PLOT_TYPES
         The type of cross sections to calculate
     temperature : float, optional

--- a/tests/unit_tests/test_plotter.py
+++ b/tests/unit_tests/test_plotter.py
@@ -41,3 +41,17 @@ def test_calculate_cexs_with_element(this, data_type):
     assert len(energy_grid) > 1
     assert len(data) == 1
     assert len(data[0]) == len(energy_grid)
+
+    # two types (reaction)
+    energy_grid, data = openmc.plotter.calculate_cexs(
+        this=this, data_type=data_type, types=[2, "elastic"]
+    )
+
+    assert isinstance(energy_grid, np.ndarray)
+    assert isinstance(data, np.ndarray)
+    assert len(energy_grid) > 1
+    assert len(data) == 2
+    assert len(data[0]) == len(energy_grid)
+    assert len(data[0]) == len(energy_grid)
+    # reactions are both the same MT number 2 is elastic
+    assert np.array_equal(data[0], data[1])

--- a/tests/unit_tests/test_plotter.py
+++ b/tests/unit_tests/test_plotter.py
@@ -1,5 +1,6 @@
-import openmc
 import numpy as np
+import openmc
+import pytest
 
 
 def test_calculate_cexs_elem_mat_sab():
@@ -18,6 +19,21 @@ def test_calculate_cexs_elem_mat_sab():
         mat_1,
         ["inelastic"],
         sab_name="c_C6H6",
+    )
+
+    assert isinstance(energy_grid, np.ndarray)
+    assert isinstance(data, np.ndarray)
+    assert len(energy_grid) > 1
+    assert len(data) == 1
+    assert len(data[0]) == len(energy_grid)
+
+
+@pytest.mark.parametrize("this, data_type", [("Li", "element"), ("Li6", "nuclide")])
+def test_calculate_cexs_with_element(this, data_type):
+
+    # single type (reaction)
+    energy_grid, data = openmc.plotter.calculate_cexs(
+        this=this, data_type=data_type, types=[205]
     )
 
     assert isinstance(energy_grid, np.ndarray)

--- a/tests/unit_tests/test_plotter.py
+++ b/tests/unit_tests/test_plotter.py
@@ -72,7 +72,7 @@ def test_calculate_cexs_with_materials(test_mat):
     assert len(data[0]) == len(energy_grid)
 
 
-@pytest.mark.parametrize("this", ["Be", "Be9", openmc.Nuclide('Be9'), openmc.Element('Be'), openmc.Macroscopic('UO2')])
+@pytest.mark.parametrize("this", ["Be", "Be9", openmc.Nuclide('Be9'), openmc.Element('Be')])
 def test_plot_xs(this):
     assert isinstance(openmc.plotter.plot_xs(this, types=['total']), Figure)
 

--- a/tests/unit_tests/test_plotter.py
+++ b/tests/unit_tests/test_plotter.py
@@ -1,22 +1,26 @@
 import numpy as np
 import openmc
 import pytest
+from matplotlib.figure import Figure
 
 
-def test_calculate_cexs_elem_mat_sab():
-    """Checks that sab cross sections are included in the
-    _calculate_cexs_elem_mat method and have the correct shape"""
-
+@pytest.fixture(scope='module')
+def test_mat():
     mat_1 = openmc.Material()
     mat_1.add_element("H", 4.0, "ao")
     mat_1.add_element("O", 4.0, "ao")
     mat_1.add_element("C", 4.0, "ao")
+    return mat_1
 
-    mat_1.add_s_alpha_beta("c_C6H6")
-    mat_1.set_density("g/cm3", 0.865)
+def test_calculate_cexs_elem_mat_sab(test_mat):
+    """Checks that sab cross sections are included in the
+    _calculate_cexs_elem_mat method and have the correct shape"""
+
+    test_mat.add_s_alpha_beta("c_C6H6")
+    test_mat.set_density("g/cm3", 0.865)
 
     energy_grid, data = openmc.plotter._calculate_cexs_elem_mat(
-        mat_1,
+        test_mat,
         ["inelastic"],
         sab_name="c_C6H6",
     )
@@ -29,8 +33,7 @@ def test_calculate_cexs_elem_mat_sab():
 
 
 @pytest.mark.parametrize("this", ["Li", "Li6"])
-def test_calculate_cexs_with_element(this):
-
+def test_calculate_cexs_with_nuclide_and_element(this):
     # single type (reaction)
     energy_grid, data = openmc.plotter.calculate_cexs(
         this=this, types=[205]
@@ -42,7 +45,7 @@ def test_calculate_cexs_with_element(this):
     assert len(data) == 1
     assert len(data[0]) == len(energy_grid)
 
-    # two types (reaction)
+    # two types (reactions)
     energy_grid, data = openmc.plotter.calculate_cexs(
         this=this, types=[2, "elastic"]
     )
@@ -55,3 +58,24 @@ def test_calculate_cexs_with_element(this):
     assert len(data[0]) == len(energy_grid)
     # reactions are both the same MT number 2 is elastic
     assert np.array_equal(data[0], data[1])
+
+
+def test_calculate_cexs_with_materials(test_mat):
+    energy_grid, data = openmc.plotter.calculate_cexs(
+        this=test_mat, types=[205]
+    )
+
+    assert isinstance(energy_grid, np.ndarray)
+    assert isinstance(data, np.ndarray)
+    assert len(energy_grid) > 1
+    assert len(data) == 1
+    assert len(data[0]) == len(energy_grid)
+
+
+@pytest.mark.parametrize("this", ["Be", "Be9"])
+def test_plot_xs(this):
+    assert isinstance(openmc.plotter.plot_xs(this, types=['total']), Figure)
+
+
+def test_plot_xs_mat(test_mat):
+    assert isinstance(openmc.plotter.plot_xs(test_mat, types=['total']), Figure)

--- a/tests/unit_tests/test_plotter.py
+++ b/tests/unit_tests/test_plotter.py
@@ -28,12 +28,12 @@ def test_calculate_cexs_elem_mat_sab():
     assert len(data[0]) == len(energy_grid)
 
 
-@pytest.mark.parametrize("this, data_type", [("Li", "element"), ("Li6", "nuclide")])
-def test_calculate_cexs_with_element(this, data_type):
+@pytest.mark.parametrize("this", ["Li", "Li6"])
+def test_calculate_cexs_with_element(this):
 
     # single type (reaction)
     energy_grid, data = openmc.plotter.calculate_cexs(
-        this=this, data_type=data_type, types=[205]
+        this=this, types=[205]
     )
 
     assert isinstance(energy_grid, np.ndarray)
@@ -44,7 +44,7 @@ def test_calculate_cexs_with_element(this, data_type):
 
     # two types (reaction)
     energy_grid, data = openmc.plotter.calculate_cexs(
-        this=this, data_type=data_type, types=[2, "elastic"]
+        this=this, types=[2, "elastic"]
     )
 
     assert isinstance(energy_grid, np.ndarray)

--- a/tests/unit_tests/test_plotter.py
+++ b/tests/unit_tests/test_plotter.py
@@ -32,7 +32,7 @@ def test_calculate_cexs_elem_mat_sab(test_mat):
     assert len(data[0]) == len(energy_grid)
 
 
-@pytest.mark.parametrize("this", ["Li", "Li6"])
+@pytest.mark.parametrize("this", ["Li", "Li6", openmc.Nuclide('Li6'), openmc.Element('Li')])
 def test_calculate_cexs_with_nuclide_and_element(this):
     # single type (reaction)
     energy_grid, data = openmc.plotter.calculate_cexs(
@@ -72,7 +72,7 @@ def test_calculate_cexs_with_materials(test_mat):
     assert len(data[0]) == len(energy_grid)
 
 
-@pytest.mark.parametrize("this", ["Be", "Be9"])
+@pytest.mark.parametrize("this", ["Be", "Be9", openmc.Nuclide('Be9'), openmc.Element('Be'), openmc.Macroscopic('UO2')])
 def test_plot_xs(this):
     assert isinstance(openmc.plotter.plot_xs(this, types=['total']), Figure)
 


### PR DESCRIPTION
I took a look at removing the ```data_type``` arg in the plotter.py file.

```data_type``` is used to identity if the ```this``` argument is a nuclide, element, macroscopic or a material. This is a bit more complex that a simple type check as strings are also accepted for element and nuclide.

I think we can automatically determine the type of plotting (element, nuclide, macroscopic or material) needed . If ```this``` is a string we can check if the string appears in the list of elements and if it does then it is an element and if it does not then it is a nuclide. Materials and Macroscopic appear to just be supported if they are openmc.Material and openmc.Macroscopic classes respectively (so no need to check if a string is used in those cases)

I believe this keeps the same functionality as before however I think the plot_xs didn't previously worked with a openmc.Macroscopic type.