### PR TITLE
added get_reaction_pathways_to_target

### DIFF
--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -17,7 +17,7 @@ import lxml.etree as ET
 import scipy.sparse as sp
 
 from openmc.checkvalue import check_type, check_greater_than
-from openmc.data import gnds_name, zam
+from openmc.data import gnds_name, zam, DADZ
 from .nuclide import FissionYieldDistribution, Nuclide
 import openmc.data
 
@@ -741,6 +741,36 @@ class Chain:
         matrix_dok = sp.dok_matrix((n, n))
         dict.update(matrix_dok, matrix)
         return matrix_dok.tocsc()
+
+    def get_reaction_pathways_to_target(self):
+        """Return a dictionary with reaction pathways to targets.
+
+        Returns
+        -------
+        pathways : dict
+            dict of targets nuclide as keys with a list of reactions and nuclides
+            as the dictionary value. For example the reaction pathways for Gold
+
+                chain.get_reaction_pathways_to_target()["Au197"]
+                    [('Hg197', '(n,p)'), ('Hg197_m1', '(n,p)'),
+                    ('Hg198', '(n,np)'), ('Hg198', '(n,d)')]
+        """
+
+        reaction_pathways = {}
+        for nuclide in self.nuclides:
+            for reaction in nuclide.reactions:
+                # if the reaction changes the A or Z number.
+                if reaction.type in DADZ.keys():
+                    secondaries  = openmc.deplete.REACTIONS[reaction.type].secondaries
+                    # includes secondary such as H1, H2, H3, He3 and He4
+                    for secondary in secondaries:
+                        reaction_pathways.setdefault(
+                            secondary, []
+                        ).append((nuclide.name, reaction.type))
+                    reaction_pathways.setdefault(
+                        reaction.target, []
+                    ).append((nuclide.name, reaction.type))
+        return reaction_pathways
 
     def get_branch_ratios(self, reaction="(n,gamma)"):
         """Return a dictionary with reaction branching ratios

--- a/tests/unit_tests/test_deplete_chain.py
+++ b/tests/unit_tests/test_deplete_chain.py
@@ -580,3 +580,15 @@ def test_reduce(gnd_simple_chain, endf_chain):
     reduced_chain = endf_chain.reduce(['U235'])
     assert 'H1' in reduced_chain
     assert 'H2' in reduced_chain
+
+def test_chain_sources(endf_chain):
+    pathways = endf_chain.get_reaction_pathways_to_target()
+    assert isinstance(pathways, dict)
+    assert isinstance(pathways['Au197'], list)
+    assert isinstance(pathways['Au197'][0], tuple)
+    assert isinstance(pathways['Au197'][0][0], str)
+    assert isinstance(pathways['Au197'][0][1], str)
+    for nuc, reaction in pathways['Au197']:
+        # checks nuclide is acceptable ZAM
+        _ = openmc.data.zam(nuc)
+        assert reaction in openmc.data.REACTION_MT.keys()

--- a/tests/unit_tests/test_deplete_chain.py
+++ b/tests/unit_tests/test_deplete_chain.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import numpy as np
 from openmc.mpi import comm
 from openmc.deplete import Chain, reaction_rates, nuclide, cram, pool
+from openmc.data import zam, REACTION_MT
 from openmc.stats import Discrete
 import pytest
 
@@ -581,14 +582,14 @@ def test_reduce(gnd_simple_chain, endf_chain):
     assert 'H1' in reduced_chain
     assert 'H2' in reduced_chain
 
-def test_chain_sources(endf_chain):
-    pathways = endf_chain.get_reaction_pathways_to_target()
+def test_chain_sources(gnd_simple_chain):
+    pathways = gnd_simple_chain.get_reaction_pathways_to_target()
     assert isinstance(pathways, dict)
-    assert isinstance(pathways['Au197'], list)
-    assert isinstance(pathways['Au197'][0], tuple)
-    assert isinstance(pathways['Au197'][0][0], str)
-    assert isinstance(pathways['Au197'][0][1], str)
-    for nuc, reaction in pathways['Au197']:
+    assert isinstance(pathways['Xe136'], list)
+    assert isinstance(pathways['Xe136'][0], tuple)
+    assert isinstance(pathways['Xe136'][0][0], str)
+    assert isinstance(pathways['Xe136'][0][1], str)
+    for nuc, reaction in pathways['Xe136']:
         # checks nuclide is acceptable ZAM
-        _ = openmc.data.zam(nuc)
-        assert reaction in openmc.data.REACTION_MT.keys()
+        _ = zam(nuc)
+        assert reaction in REACTION_MT.keys()


### PR DESCRIPTION
# Description

This PR proposes a method of getting the reaction pathways from a openmc.chain object. We have a few other get methods in the chain class so I wonder if more methods are welcome or if this is unessecary bloat. Naturally I find it useful to be able to find the reaction pathways to a specific target nuclide. 

For example here is the user code that gets the reaction pathways for making stable Gold which surely everyone would want to know.

example usage

```python
import os
import openmc
import openmc.deplete
chain_file = os.environ['OPENMC_CHAIN_FILE']
chain = openmc.deplete.Chain.from_xml(chain_file)
pathways = chain.get_reaction_pathways_to_target()
pathways['Au197']
>>> [('Hg197', '(n,p)'), ('Hg197_m1', '(n,p)'), ('Hg198', '(n,np)'), ('Hg198', '(n,d)')]
```

In addition to the chain reactions this method also accounts for secondaries so that the pathways for producing helium or hydrogen isotopes can also be found like this ```tritium_pathways=pathways['H3']```

I've added some simple tests that check the types and contents on the returned dictionary

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
