### PR TITLE
avoid adding ParticleNuclideFilter multiple times to tally in prepare_tallies

### DIFF
--- a/openmc/deplete/d1s.py
+++ b/openmc/deplete/d1s.py
@@ -243,9 +243,7 @@ def prepare_tallies(
         for f in tally.filters:
             if isinstance(f, openmc.ParticleFilter):
                 if list(f.bins) == ['photon']:
-                    for filter in tally.filters:
-                        # avoid adding the ParentNuclideFilter multiple times
-                        if isinstance(filter, openmc.ParentNuclideFilter):
-                            break
+                    if not tally.contains_filter(openmc.ParentNuclideFilter):
                         tally.filters.append(filter)
+                    break
     return nuclides

--- a/openmc/deplete/d1s.py
+++ b/openmc/deplete/d1s.py
@@ -243,7 +243,9 @@ def prepare_tallies(
         for f in tally.filters:
             if isinstance(f, openmc.ParticleFilter):
                 if list(f.bins) == ['photon']:
-                    tally.filters.append(filter)
-                    break
-
+                    for filter in tally.filters:
+                        # avoid adding the ParentNuclideFilter multiple times
+                        if isinstance(filter, openmc.ParentNuclideFilter):
+                            break
+                        tally.filters.append(filter)
     return nuclides

--- a/tests/unit_tests/test_d1s.py
+++ b/tests/unit_tests/test_d1s.py
@@ -84,6 +84,11 @@ def test_prepare_tallies(model):
     assert tally.contains_filter(openmc.ParentNuclideFilter)
     assert sorted(tally.filters[-1].bins) == sorted(radionuclides)
 
+    assert len(tally.filters) == 2
+    # calling prepare_tallies twice should not add another ParentNuclideFilter
+    d1s.prepare_tallies(model, chain_file=CHAIN_PATH)
+    assert len(tally.filters) == 2
+
 
 def test_apply_time_correction(run_in_tmpdir):
     # Make simple sphere model with elemental Ni


### PR DESCRIPTION
# Description

This Pr adds a check to ensure that the prepare_tallies function in d1s doesn't add a particle filter to a tally if the tally already has a particle filter.

I noticed this is a potential issue if the user is performing d1s studies with mixed dd and dt pulses, it is easy to overly prepare the tallies and get strange results as a consequence. I have accidentally "over prepared tallies" and it took a while to realize what was going wrong.

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)