### PR TITLE
added session

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -2086,7 +2086,7 @@ class Materials(cv.CheckedList):
                     chain_file=chain,
                     temperature=temperature,
                     reactions=reactions,
-                    session=session
+                    session=session,
                 )
                 micros.append(micro_xs)
                 fluxes.append(material.volume)

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -2075,7 +2075,7 @@ class Materials(cv.CheckedList):
         micros = []
         fluxes = []
 
-        with openmc.lib.TemporarySession():
+        with openmc.lib.TemporarySession() as session:
             for material, flux, energy in zip(
                 self, multigroup_fluxes, energy_group_structures
             ):
@@ -2086,6 +2086,7 @@ class Materials(cv.CheckedList):
                     chain_file=chain,
                     temperature=temperature,
                     reactions=reactions,
+                    session=session
                 )
                 micros.append(micro_xs)
                 fluxes.append(material.volume)


### PR DESCRIPTION
# Description

I noticed that in the example for the example TemporarySession provided in [this PR](https://github.com/openmc-dev/openmc/pull/3475#issue-3183380203) opens the context manager as ```session``` and passes ```session``` to the ```MicroXS.from_multigroup_flux``` function. Perhaps we should also do that in ```openmc.deplete``` 

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code

- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
