### PR TITLE
Speed up time correction factors

### DIFF
--- a/openmc/deplete/d1s.py
+++ b/openmc/deplete/d1s.py
@@ -103,8 +103,8 @@ def time_correction_factors(
     timesteps = np.asarray(timesteps)
     source_rates = np.asarray(source_rates)
 
-    # Calculate decay rate for each nuclide (cache log(2))
     log_2 = log(2.0)
+    # Calculate decay rate for each nuclide with cached log(2)
     decay_rate = np.array([log_2 / half_life(x) for x in nuclides])
 
     n_timesteps = len(timesteps) + 1
@@ -119,7 +119,7 @@ def time_correction_factors(
     g_matrix = np.exp(-decay_dt_matrix)
     one_minus_g_matrix = -np.expm1(-decay_dt_matrix)
 
-    # Apply recurrence relation step by step (cannot be fully vectorized due to dependency)
+    # Apply recurrence relation step by step
     for i in range(len(timesteps)):
         # Eq. (4) in doi:10.1016/j.fusengdes.2019.111399
         h[i + 1] = source_rates[i] * one_minus_g_matrix[i] + h[i] * g_matrix[i]


### PR DESCRIPTION
# Description

speeds up the time_correction_factors function by vectorizing 

example script used for testing
```python
import time
from pathlib import Path
import openmc
from openmc.deplete import d1s
radionuclides = ['Co60', 'U238', 'Na22', 'Li8', 'H3']
start_time = time.time()
time_factors_dt = d1s.time_correction_factors(
    nuclides=radionuclides,
    timesteps=[1, 100, 100,100, 100],
    source_rates=[1e20,0,0,0,0,],
    timestep_units = 's'
)
print(f"function time: {time.time() - start_time:.4f} seconds")
```

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)

