### PR TITLE
moved append to new line

### DIFF
--- a/openmc/mgxs_library.py
+++ b/openmc/mgxs_library.py
@@ -484,7 +484,8 @@ class XSdata:
 
         check_type('temperature', temperature, Real)
 
-        temp_store = self.temperatures.tolist().append(temperature)
+        temp_store = self.temperatures.tolist()
+        temp_store.append(temperature)
         self.temperatures = temp_store
 
         self._total.append(None)


### PR DESCRIPTION
# Description

I think this line is ```temp_store = self.temperatures.tolist().append(temperature)``` is setting ```self.temperatures``` to ```None``` and append returns None.

```python
>>> list_appended = [1,2,3,4].append(5)
>>> print(list_appended)
None
```

Perhaps the desired behavior is achieved if we split this over two lines

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
