### PR TITLE
materials have names after depletion

### DIFF
--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -209,7 +209,7 @@ class TransportOperator(ABC):
             simulation.
         full_burn_list : list of int
             All burnable materials in the geometry.
-        mat_name : dict of str to str
+        name_list : dict of str to str
             Material names corresponding to materials in burn_list
         """
 

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -209,7 +209,7 @@ class TransportOperator(ABC):
             simulation.
         full_burn_list : list of int
             All burnable materials in the geometry.
-        name_list : dict of str to str
+        name_list : list of str
             Material names corresponding to materials in burn_list
         """
 

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -209,6 +209,8 @@ class TransportOperator(ABC):
             simulation.
         full_burn_list : list of int
             All burnable materials in the geometry.
+        mat_name : dict of str to str
+            Material names corresponding to materials in burn_list
         """
 
     def finalize(self):

--- a/openmc/deplete/openmc_operator.py
+++ b/openmc/deplete/openmc_operator.py
@@ -197,6 +197,7 @@ class OpenMCOperator(TransportOperator):
         burnable_mats = set()
         model_nuclides = set()
         volume = {}
+        mat_name = {}
 
         self.heavy_metal = 0.0
 
@@ -221,6 +222,7 @@ class OpenMCOperator(TransportOperator):
                                f"with ID={mat.id} Name={mat.name}.")
                     raise RuntimeError(msg)
                 volume[str(mat.id)] = mat.volume
+                mat_name[str(mat.id)] = mat.name
                 self.heavy_metal += mat.fissionable_mass
 
         # Make sure there are burnable materials
@@ -231,6 +233,9 @@ class OpenMCOperator(TransportOperator):
         # Sort the sets
         burnable_mats = sorted(burnable_mats, key=int)
         model_nuclides = sorted(model_nuclides)
+
+        # Store material names for later use
+        self.mat_name = mat_name
 
         # Construct a global nuclide dictionary, burned first
         nuclides = list(self.chain.nuclide_dict)
@@ -541,6 +546,8 @@ class OpenMCOperator(TransportOperator):
             A list of all material IDs to be burned.  Used for sorting the simulation.
         full_burn_list : list
             List of all burnable material IDs
+        mat_name : dict of str to str
+            Material names corresponding to materials in full_burn_dict
 
         """
         nuc_list = self.number.burnable_nuclides
@@ -554,4 +561,4 @@ class OpenMCOperator(TransportOperator):
         volume_list = comm.allgather(volume)
         volume = {k: v for d in volume_list for k, v in d.items()}
 
-        return volume, nuc_list, burn_list, self.burnable_mats
+        return volume, nuc_list, burn_list, self.burnable_mats, self.mat_name

--- a/openmc/deplete/openmc_operator.py
+++ b/openmc/deplete/openmc_operator.py
@@ -197,7 +197,7 @@ class OpenMCOperator(TransportOperator):
         burnable_mats = set()
         model_nuclides = set()
         volume = {}
-        mat_name = {}
+        name_list = {}
 
         self.heavy_metal = 0.0
 
@@ -222,7 +222,7 @@ class OpenMCOperator(TransportOperator):
                                f"with ID={mat.id} Name={mat.name}.")
                     raise RuntimeError(msg)
                 volume[str(mat.id)] = mat.volume
-                mat_name[str(mat.id)] = mat.name
+                name_list[str(mat.id)] = mat.name
                 self.heavy_metal += mat.fissionable_mass
 
         # Make sure there are burnable materials
@@ -235,7 +235,7 @@ class OpenMCOperator(TransportOperator):
         model_nuclides = sorted(model_nuclides)
 
         # Store material names for later use
-        self.mat_name = mat_name
+        self.name_list = name_list
 
         # Construct a global nuclide dictionary, burned first
         nuclides = list(self.chain.nuclide_dict)
@@ -546,7 +546,7 @@ class OpenMCOperator(TransportOperator):
             A list of all material IDs to be burned.  Used for sorting the simulation.
         full_burn_list : list
             List of all burnable material IDs
-        mat_name : dict of str to str
+        name_list : dict of str to str
             Material names corresponding to materials in full_burn_dict
 
         """
@@ -561,4 +561,4 @@ class OpenMCOperator(TransportOperator):
         volume_list = comm.allgather(volume)
         volume = {k: v for d in volume_list for k, v in d.items()}
 
-        return volume, nuc_list, burn_list, self.burnable_mats, self.mat_name
+        return volume, nuc_list, burn_list, self.burnable_mats, self.name_list

--- a/openmc/deplete/openmc_operator.py
+++ b/openmc/deplete/openmc_operator.py
@@ -197,7 +197,6 @@ class OpenMCOperator(TransportOperator):
         burnable_mats = set()
         model_nuclides = set()
         volume = {}
-        name_list = {}
 
         self.heavy_metal = 0.0
 
@@ -212,7 +211,7 @@ class OpenMCOperator(TransportOperator):
                            "section data.")
                     warn(msg)
             if mat.depletable:
-                burnable_mats.add(str(mat.id))
+                burnable_mats.add((str(mat.id), mat.name))
                 if mat.volume is None:
                     if mat.name is None:
                         msg = ("Volume not specified for depletable material "
@@ -222,7 +221,6 @@ class OpenMCOperator(TransportOperator):
                                f"with ID={mat.id} Name={mat.name}.")
                     raise RuntimeError(msg)
                 volume[str(mat.id)] = mat.volume
-                name_list[str(mat.id)] = mat.name
                 self.heavy_metal += mat.fissionable_mass
 
         # Make sure there are burnable materials
@@ -231,11 +229,13 @@ class OpenMCOperator(TransportOperator):
                 "No depletable materials were found in the model.")
 
         # Sort the sets
-        burnable_mats = sorted(burnable_mats, key=int)
+        burnable_mats = sorted(burnable_mats, key=lambda x:int(x[0]))
         model_nuclides = sorted(model_nuclides)
 
         # Store material names for later use
-        self.name_list = name_list
+        self.name_list = [name for mat_id, name in burnable_mats]
+
+        burnable_mats = [mat_id for mat_id, name in burnable_mats]
 
         # Construct a global nuclide dictionary, burned first
         nuclides = list(self.chain.nuclide_dict)
@@ -546,8 +546,8 @@ class OpenMCOperator(TransportOperator):
             A list of all material IDs to be burned.  Used for sorting the simulation.
         full_burn_list : list
             List of all burnable material IDs
-        name_list : dict of str to str
-            Material names corresponding to materials in full_burn_dict
+        name_list : list of str
+            Material names corresponding to materials in burn_list
 
         """
         nuc_list = self.number.burnable_nuclides

--- a/openmc/deplete/stepresult.py
+++ b/openmc/deplete/stepresult.py
@@ -70,6 +70,7 @@ class StepResult:
         self.index_mat = None
         self.index_nuc = None
         self.mat_to_hdf5_ind = None
+        self.mat_name = None
 
         self.data = None
 
@@ -138,7 +139,7 @@ class StepResult:
     def n_hdf5_mats(self):
         return len(self.mat_to_hdf5_ind)
 
-    def allocate(self, volume, nuc_list, burn_list, full_burn_list):
+    def allocate(self, volume, nuc_list, burn_list, full_burn_list, mat_name=None):
         """Allocate memory for depletion step data
 
         Parameters
@@ -151,12 +152,15 @@ class StepResult:
             A list of all mat IDs to be burned.  Used for sorting the simulation.
         full_burn_list : list of str
             List of all burnable material IDs
+        mat_name : dict of str to str, optional
+            Material names corresponding to materials in full_burn_dict
 
         """
         self.volume = copy.deepcopy(volume)
         self.index_nuc = {nuc: i for i, nuc in enumerate(nuc_list)}
         self.index_mat = {mat: i for i, mat in enumerate(burn_list)}
         self.mat_to_hdf5_ind = {mat: i for i, mat in enumerate(full_burn_list)}
+        self.mat_name = copy.deepcopy(mat_name) if mat_name is not None else {}
 
         # Create storage array
         self.data = np.zeros((self.n_mat, self.n_nuc))
@@ -184,7 +188,7 @@ class StepResult:
 
         # Direct transfer
         direct_attrs = ("time", "k", "source_rate", "index_nuc",
-                        "mat_to_hdf5_ind", "proc_time")
+                        "mat_to_hdf5_ind", "mat_name", "proc_time")
         for attr in direct_attrs:
             setattr(new, attr, getattr(self, attr))
         # Get applicable slice of data
@@ -223,6 +227,8 @@ class StepResult:
                 f'mat_id {mat_id} not found in StepResult. Available mat_id '
                 f'values are {list(self.volume.keys())}'
             ) from e
+        if self.mat_name and mat_id in self.mat_name:
+            material.name = self.mat_name[mat_id]
         for nuc, _ in sorted(self.index_nuc.items(), key=lambda x: x[1]):
             atoms = self[mat_id, nuc]
             if atoms <= 0.0:
@@ -313,6 +319,8 @@ class StepResult:
             mat_single_group = mat_group.create_group(mat)
             mat_single_group.attrs["index"] = self.mat_to_hdf5_ind[mat]
             mat_single_group.attrs["volume"] = self.volume[mat]
+            if self.mat_name and mat in self.mat_name:
+                mat_single_group.attrs["name"] = self.mat_name[mat]
 
         nuc_group = handle.create_group("nuclides")
 
@@ -495,6 +503,7 @@ class StepResult:
         results.volume = {}
         results.index_mat = {}
         results.index_nuc = {}
+        results.mat_name = {}
         rxn_nuc_to_ind = {}
         rxn_to_ind = {}
 
@@ -504,6 +513,8 @@ class StepResult:
 
             results.volume[mat] = vol
             results.index_mat[mat] = ind
+            if "name" in mat_handle.attrs:
+                results.mat_name[mat] = mat_handle.attrs["name"]
 
         for nuc, nuc_handle in handle["/nuclides"].items():
             ind_atom = nuc_handle.attrs["atom number index"]
@@ -569,11 +580,11 @@ class StepResult:
             .. versionadded:: 0.14.0
         """
         # Get indexing terms
-        vol_dict, nuc_list, burn_list, full_burn_list = op.get_results_info()
+        vol_dict, nuc_list, burn_list, full_burn_list, mat_name = op.get_results_info()
 
         # Create results
         results = StepResult()
-        results.allocate(vol_dict, nuc_list, burn_list, full_burn_list)
+        results.allocate(vol_dict, nuc_list, burn_list, full_burn_list, mat_name)
 
         n_mat = len(burn_list)
 

--- a/openmc/deplete/stepresult.py
+++ b/openmc/deplete/stepresult.py
@@ -70,7 +70,7 @@ class StepResult:
         self.index_mat = None
         self.index_nuc = None
         self.mat_to_hdf5_ind = None
-        self.mat_name = None
+        self.name_list = None
 
         self.data = None
 
@@ -139,7 +139,7 @@ class StepResult:
     def n_hdf5_mats(self):
         return len(self.mat_to_hdf5_ind)
 
-    def allocate(self, volume, nuc_list, burn_list, full_burn_list, mat_name=None):
+    def allocate(self, volume, nuc_list, burn_list, full_burn_list, name_list=None):
         """Allocate memory for depletion step data
 
         Parameters
@@ -152,7 +152,7 @@ class StepResult:
             A list of all mat IDs to be burned.  Used for sorting the simulation.
         full_burn_list : list of str
             List of all burnable material IDs
-        mat_name : dict of str to str, optional
+        name_list : dict of str to str, optional
             Material names corresponding to materials in full_burn_dict
 
         """
@@ -160,7 +160,7 @@ class StepResult:
         self.index_nuc = {nuc: i for i, nuc in enumerate(nuc_list)}
         self.index_mat = {mat: i for i, mat in enumerate(burn_list)}
         self.mat_to_hdf5_ind = {mat: i for i, mat in enumerate(full_burn_list)}
-        self.mat_name = copy.deepcopy(mat_name) if mat_name is not None else {}
+        self.name_list = copy.deepcopy(name_list) if name_list is not None else {}
 
         # Create storage array
         self.data = np.zeros((self.n_mat, self.n_nuc))
@@ -188,7 +188,7 @@ class StepResult:
 
         # Direct transfer
         direct_attrs = ("time", "k", "source_rate", "index_nuc",
-                        "mat_to_hdf5_ind", "mat_name", "proc_time")
+                        "mat_to_hdf5_ind", "name_list", "proc_time")
         for attr in direct_attrs:
             setattr(new, attr, getattr(self, attr))
         # Get applicable slice of data
@@ -227,8 +227,8 @@ class StepResult:
                 f'mat_id {mat_id} not found in StepResult. Available mat_id '
                 f'values are {list(self.volume.keys())}'
             ) from e
-        if self.mat_name and mat_id in self.mat_name:
-            material.name = self.mat_name[mat_id]
+        if self.name_list and mat_id in self.name_list:
+            material.name = self.name_list[mat_id]
         for nuc, _ in sorted(self.index_nuc.items(), key=lambda x: x[1]):
             atoms = self[mat_id, nuc]
             if atoms <= 0.0:
@@ -319,8 +319,8 @@ class StepResult:
             mat_single_group = mat_group.create_group(mat)
             mat_single_group.attrs["index"] = self.mat_to_hdf5_ind[mat]
             mat_single_group.attrs["volume"] = self.volume[mat]
-            if self.mat_name and mat in self.mat_name:
-                mat_single_group.attrs["name"] = self.mat_name[mat]
+            if self.name_list and mat in self.name_list:
+                mat_single_group.attrs["name"] = self.name_list[mat]
 
         nuc_group = handle.create_group("nuclides")
 
@@ -503,7 +503,7 @@ class StepResult:
         results.volume = {}
         results.index_mat = {}
         results.index_nuc = {}
-        results.mat_name = {}
+        results.name_list = {}
         rxn_nuc_to_ind = {}
         rxn_to_ind = {}
 
@@ -514,7 +514,7 @@ class StepResult:
             results.volume[mat] = vol
             results.index_mat[mat] = ind
             if "name" in mat_handle.attrs:
-                results.mat_name[mat] = mat_handle.attrs["name"]
+                results.name_list[mat] = mat_handle.attrs["name"]
 
         for nuc, nuc_handle in handle["/nuclides"].items():
             ind_atom = nuc_handle.attrs["atom number index"]
@@ -580,11 +580,11 @@ class StepResult:
             .. versionadded:: 0.14.0
         """
         # Get indexing terms
-        vol_dict, nuc_list, burn_list, full_burn_list, mat_name = op.get_results_info()
+        vol_dict, nuc_list, burn_list, full_burn_list, name_list = op.get_results_info()
 
         # Create results
         results = StepResult()
-        results.allocate(vol_dict, nuc_list, burn_list, full_burn_list, mat_name)
+        results.allocate(vol_dict, nuc_list, burn_list, full_burn_list, name_list)
 
         n_mat = len(burn_list)
 

--- a/openmc/deplete/stepresult.py
+++ b/openmc/deplete/stepresult.py
@@ -152,15 +152,15 @@ class StepResult:
             A list of all mat IDs to be burned.  Used for sorting the simulation.
         full_burn_list : list of str
             List of all burnable material IDs
-        name_list : dict of str to str, optional
-            Material names corresponding to materials in full_burn_dict
+        name_list : list of str, optional
+            Material names corresponding to materials in burn_list
 
         """
         self.volume = copy.deepcopy(volume)
         self.index_nuc = {nuc: i for i, nuc in enumerate(nuc_list)}
         self.index_mat = {mat: i for i, mat in enumerate(burn_list)}
         self.mat_to_hdf5_ind = {mat: i for i, mat in enumerate(full_burn_list)}
-        self.name_list = copy.deepcopy(name_list) if name_list is not None else {}
+        self.mat_to_name = dict(zip(burn_list ,name_list)) if name_list is not None else {}
 
         # Create storage array
         self.data = np.zeros((self.n_mat, self.n_nuc))
@@ -188,7 +188,7 @@ class StepResult:
 
         # Direct transfer
         direct_attrs = ("time", "k", "source_rate", "index_nuc",
-                        "mat_to_hdf5_ind", "name_list", "proc_time")
+                        "mat_to_hdf5_ind", "mat_to_name", "proc_time")
         for attr in direct_attrs:
             setattr(new, attr, getattr(self, attr))
         # Get applicable slice of data
@@ -227,8 +227,8 @@ class StepResult:
                 f'mat_id {mat_id} not found in StepResult. Available mat_id '
                 f'values are {list(self.volume.keys())}'
             ) from e
-        if self.name_list and mat_id in self.name_list:
-            material.name = self.name_list[mat_id]
+        if mat_id in self.mat_to_name:
+            material.name = self.mat_to_name[mat_id]
         for nuc, _ in sorted(self.index_nuc.items(), key=lambda x: x[1]):
             atoms = self[mat_id, nuc]
             if atoms <= 0.0:
@@ -319,8 +319,8 @@ class StepResult:
             mat_single_group = mat_group.create_group(mat)
             mat_single_group.attrs["index"] = self.mat_to_hdf5_ind[mat]
             mat_single_group.attrs["volume"] = self.volume[mat]
-            if self.name_list and mat in self.name_list:
-                mat_single_group.attrs["name"] = self.name_list[mat]
+            if mat in self.mat_to_name:
+                mat_single_group.attrs["name"] = self.mat_to_name[mat]
 
         nuc_group = handle.create_group("nuclides")
 
@@ -503,7 +503,7 @@ class StepResult:
         results.volume = {}
         results.index_mat = {}
         results.index_nuc = {}
-        results.name_list = {}
+        results.mat_to_name = {}
         rxn_nuc_to_ind = {}
         rxn_to_ind = {}
 
@@ -514,7 +514,7 @@ class StepResult:
             results.volume[mat] = vol
             results.index_mat[mat] = ind
             if "name" in mat_handle.attrs:
-                results.name_list[mat] = mat_handle.attrs["name"]
+                results.mat_to_name[mat] = mat_handle.attrs["name"]
 
         for nuc, nuc_handle in handle["/nuclides"].items():
             ind_atom = nuc_handle.attrs["atom number index"]

--- a/tests/dummy_operator.py
+++ b/tests/dummy_operator.py
@@ -243,4 +243,4 @@ class DummyOperator(TransportOperator):
             Maps cell name to index in global geometry.
 
         """
-        return self.volume, self.nuc_list, self.local_mats, self.burnable_mats
+        return self.volume, self.nuc_list, self.local_mats, self.burnable_mats, {"1": ""}

--- a/tests/unit_tests/test_deplete_activation.py
+++ b/tests/unit_tests/test_deplete_activation.py
@@ -113,6 +113,11 @@ def test_activation(run_in_tmpdir, model, reaction_rate_mode, reaction_rate_opts
     assert atoms[0] == pytest.approx(n0)
     assert atoms[1] / atoms[0] == pytest.approx(0.5, rel=tolerance)
 
+    # Check that material name is preserved in depletion results
+    step_result = results[0]
+    mat_from_results = step_result.get_material(f"{w.id}")
+    assert mat_from_results.name == 'tungsten'
+
 
 def test_decay(run_in_tmpdir):
     """Test decay-only timesteps where no transport solve is performed"""

--- a/tests/unit_tests/test_deplete_decay.py
+++ b/tests/unit_tests/test_deplete_decay.py
@@ -82,3 +82,8 @@ def test_deplete_decay_step_fissionable(run_in_tmpdir):
     _, u238 = results.get_atoms(f"{mat.id}", "U238")
 
     assert u238[1] == pytest.approx(original_atoms)
+
+    # Check that material name is preserved in depletion results
+    step_result = results[0]
+    mat_from_results = step_result.get_material(f"{mat.id}")
+    assert mat_from_results.name == 'I do not decay.'

--- a/tests/unit_tests/test_deplete_integrator.py
+++ b/tests/unit_tests/test_deplete_integrator.py
@@ -59,8 +59,9 @@ def test_results_save(run_in_tmpdir):
     burn_list = full_burn_list[2*comm.rank: 2*comm.rank + 2]
     nuc_list = ["na", "nb"]
 
+    mat_name = {mat: "" for mat in full_burn_list}
     op.get_results_info.return_value = (
-        vol_dict, nuc_list, burn_list, full_burn_list)
+        vol_dict, nuc_list, burn_list, full_burn_list, mat_name)
 
     # Construct end-of-step concentrations
     x1 = [rng.random(2), rng.random(2)]
@@ -130,7 +131,8 @@ def test_results_save_without_rates(run_in_tmpdir):
     vol_dict = {"0": 1.0}
     nuc_list = ["na"]
     burn_list = ["0"]
-    op.get_results_info.return_value = (vol_dict, nuc_list, burn_list, burn_list)
+    mat_name = {mat: "" for mat in burn_list}
+    op.get_results_info.return_value = (vol_dict, nuc_list, burn_list, burn_list, mat_name)
 
     x = [np.array([1.0])]
     rates = ReactionRates(burn_list, nuc_list, ["ra"])

--- a/tests/unit_tests/test_deplete_integrator.py
+++ b/tests/unit_tests/test_deplete_integrator.py
@@ -59,9 +59,9 @@ def test_results_save(run_in_tmpdir):
     burn_list = full_burn_list[2*comm.rank: 2*comm.rank + 2]
     nuc_list = ["na", "nb"]
 
-    mat_name = {mat: "" for mat in full_burn_list}
+    name_list = {mat: "" for mat in full_burn_list}
     op.get_results_info.return_value = (
-        vol_dict, nuc_list, burn_list, full_burn_list, mat_name)
+        vol_dict, nuc_list, burn_list, full_burn_list, name_list)
 
     # Construct end-of-step concentrations
     x1 = [rng.random(2), rng.random(2)]
@@ -131,8 +131,8 @@ def test_results_save_without_rates(run_in_tmpdir):
     vol_dict = {"0": 1.0}
     nuc_list = ["na"]
     burn_list = ["0"]
-    mat_name = {mat: "" for mat in burn_list}
-    op.get_results_info.return_value = (vol_dict, nuc_list, burn_list, burn_list, mat_name)
+    name_list = {mat: "" for mat in burn_list}
+    op.get_results_info.return_value = (vol_dict, nuc_list, burn_list, burn_list, name_list)
 
     x = [np.array([1.0])]
     rates = ReactionRates(burn_list, nuc_list, ["ra"])


### PR DESCRIPTION
# Description

When running a depletion simulation and then loading up the materials from a depletion_results.h5 file the material names are lost.

This makes depletion with DAGMC workflows a bit tricky as one typically knows the material name and not the ID in DAGMC workflows (this stems from material tags in the DAGMC file).

Anyway it would be super useful for me if we can preserve the material name when writing the depletion_results.h5 file so that I can easily find materials once again. 

I have added tests but also manually tested with this script

```python
"""Minimal OpenMC depletion example to test material name preservation."""

import openmc
import openmc.deplete
from pathlib import Path
openmc.config['cross_sections'] = Path.home() / 'nuclear_data'/ 'endf-b8.0-hdf5/' / 'cross_sections.xml'
openmc.config['chain_file'] = Path.home() / 'nuclear_data' / 'chain-endf-b8.0.xml'
fuel = openmc.Material(name="My Fuel Material", material_id=1)
fuel.add_nuclide("Fe56", 1)
fuel.set_density("g/cm3", 10.0)
fuel.depletable = True
fuel.volume = 4/3 * 3.14159 * 10**3  # sphere volume
materials = openmc.Materials()
sphere = openmc.Sphere(r=10, boundary_type="vacuum")
cell = openmc.Cell(fill=fuel, region=-sphere)
geometry = openmc.Geometry([cell])
settings = openmc.Settings()
settings.batches = 10
settings.run_mode  = 'fixed source'
settings.particles = 1000
settings.source = openmc.Source(
    space=openmc.stats.Point((0, 0, 0)),
    energy=openmc.stats.Discrete([14.0e6], [1.0])
)
model = openmc.Model(geometry, materials, settings)
model.deplete(
    method="predictor", 
    operator_kwargs={
        "normalization_mode": "source-rate",
        "chain_file": openmc.config['chain_file'],
        "reduce_chain_level": 5,
    },
    timesteps=[1,1,1,1],
    source_rates=[1e20,0,0,0],
)
results = openmc.deplete.Results("depletion_results.h5")
step = results[-1]
material = step.get_material('1')
assert material.name =="My Fuel Material"
print(material.name)
```

Fixes # (issue)

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
