### PR TITLE
Raise on duplicate material names in convert_to_multigroup

### DIFF
--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -2705,11 +2705,7 @@ class Model:
         ----------
         method : {"material_wise", "stochastic_slab", "infinite_medium"}, optional
             Method to generate the MGXS. One cross section is produced per
-            material (keyed by material name), so a material that fills several
-            cells with differing spectra is represented by a single,
-            spectrum-averaged cross section. To resolve location-specific
-            spectra, give each region its own material with a distinct name;
-            conversion raises an error if distinct materials share a name.
+            material (keyed by material name).
         groups : openmc.mgxs.EnergyGroups, str, or sequence of float, optional
             Energy group structure for the MGXS. Can be an
             :class:`openmc.mgxs.EnergyGroups` object, a string name of a

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -2704,7 +2704,12 @@ class Model:
         Parameters
         ----------
         method : {"material_wise", "stochastic_slab", "infinite_medium"}, optional
-            Method to generate the MGXS.
+            Method to generate the MGXS. One cross section is produced per
+            material (keyed by material name), so a material that fills several
+            cells with differing spectra is represented by a single,
+            spectrum-averaged cross section. To resolve location-specific
+            spectra, give each region its own material with a distinct name;
+            conversion raises an error if distinct materials share a name.
         groups : openmc.mgxs.EnergyGroups, str, or sequence of float, optional
             Energy group structure for the MGXS. Can be an
             :class:`openmc.mgxs.EnergyGroups` object, a string name of a
@@ -2778,6 +2783,20 @@ class Model:
                 if not material.name or not material.name.strip():
                     material.name = f"material {material.id}"
                 material.name = re.sub(r'[^a-zA-Z0-9]', '_', material.name)
+
+            # The MGXS library keys cross section data by material name, so
+            # distinct materials that share a name cannot be written separately.
+            name_to_ids = {}
+            for material in self.materials:
+                name_to_ids.setdefault(material.name, set()).add(material.id)
+            shared = sorted(
+                name for name, ids in name_to_ids.items() if len(ids) > 1
+            )
+            if shared:
+                raise ValueError(
+                    "Each material must have a unique name to be written to the "
+                    f"MGXS library, but these names are shared: {shared}."
+                )
 
             # If needed, generate the needed MGXS data library file
             if not Path(mgxs_path).is_file() or overwrite_mgxs_library:

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -1038,3 +1038,25 @@ def test_id_map_to_rgb():
     )
     # Check that overlap region is green
     assert np.allclose(rgb_overlap[5:, 5:], [0.0, 1.0, 0.0])
+
+
+def test_convert_to_multigroup_raises_on_duplicate_material_names(run_in_tmpdir):
+    """Distinct materials that share a name must raise rather than silently
+    collapse to a single cross section in the MGXS library."""
+    steel_a = openmc.Material(name="steel")
+    steel_a.add_element("Fe", 1.0)
+    steel_a.set_density("g/cm3", 7.9)
+    steel_b = openmc.Material(name="steel")
+    steel_b.add_element("Fe", 1.0)
+    steel_b.set_density("g/cm3", 7.9)
+
+    s1 = openmc.Sphere(r=1.0)
+    s2 = openmc.Sphere(r=2.0, boundary_type="vacuum")
+    c1 = openmc.Cell(fill=steel_a, region=-s1)
+    c2 = openmc.Cell(fill=steel_b, region=+s1 & -s2)
+    model = openmc.Model(
+        openmc.Geometry([c1, c2]), openmc.Materials([steel_a, steel_b])
+    )
+
+    with pytest.raises(ValueError, match="unique name"):
+        model.convert_to_multigroup(method="material_wise")


### PR DESCRIPTION
## Summary

`Model.convert_to_multigroup()` generates one MGXS per material, keyed by material name. Two **distinct** materials that share a name would be silently written as a single cross section — one material's data overwrites the other's, dropping a material. This is easy to hit because `Material.clone()` (used by `Model.differentiate_mats()`) preserves the original name, and because names are sanitised to alphanumeric + underscore, which can make otherwise-distinct names collide.

Conversion now **raises a `ValueError`** instead of silently producing an incorrect library; material names are left unchanged. The per-material granularity is also noted in the `convert_to_multigroup` docstring.

## Tests

Added a unit test asserting that two distinct materials sharing a name raise `ValueError`.