### PR TITLE
Add input validation for plot arguments

### DIFF
--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -21,7 +21,8 @@ import openmc
 import openmc._xml as xml
 from openmc.dummy_comm import DummyCommunicator
 from openmc.executor import _process_CLI_arguments
-from openmc.checkvalue import check_type, check_value, PathLike
+from openmc.checkvalue import (check_type, check_value, check_greater_than,
+                               PathLike)
 from openmc.exceptions import InvalidIDError
 from openmc.plots import add_plot_params, _BASIS_INDICES, id_map_to_rgb
 from openmc.utility_funcs import change_directory
@@ -1301,7 +1302,11 @@ class Model:
         import matplotlib.pyplot as plt
 
         check_type('n_samples', n_samples, int | None)
+        if n_samples is not None:
+            check_greater_than('n_samples', n_samples, 0, equality=True)
         check_type('plane_tolerance', plane_tolerance, Real)
+        check_greater_than('plane_tolerance', plane_tolerance, 0.0)
+
         if legend_kwargs is None:
             legend_kwargs = {}
         legend_kwargs.setdefault('bbox_to_anchor', (1.05, 1))

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -22,7 +22,7 @@ import openmc._xml as xml
 from openmc.dummy_comm import DummyCommunicator
 from openmc.executor import _process_CLI_arguments
 from openmc.checkvalue import (check_type, check_value, check_greater_than,
-                               PathLike)
+                               check_length, PathLike)
 from openmc.exceptions import InvalidIDError
 from openmc.plots import add_plot_params, _BASIS_INDICES, id_map_to_rgb
 from openmc.utility_funcs import change_directory
@@ -1051,6 +1051,13 @@ class Model:
         pixels: int | Sequence[int],
         basis: str
     ):
+        if isinstance(pixels, int):
+            check_greater_than('pixels', pixels, 0)
+        else:
+            check_length('pixels', pixels, 2)
+            for p in pixels:
+                check_greater_than('pixels', p, 0)
+
         x, y, _ = _BASIS_INDICES[basis]
 
         bb = self.bounding_box

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -673,6 +673,12 @@ def test_model_plot_invalid_inputs():
         model.plot(plane_tolerance=0.0)
     with pytest.raises(TypeError):
         model.plot(plane_tolerance='1')
+    with pytest.raises(ValueError):
+        model.plot(pixels=-1)
+    with pytest.raises(ValueError):
+        model.plot(pixels=(0, 100))
+    with pytest.raises(ValueError):
+        model.plot(pixels=(100,))
 
 
 def test_model_id_map_initialization(run_in_tmpdir):

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -660,6 +660,21 @@ def test_model_plot():
     plt.close('all')
 
 
+def test_model_plot_invalid_inputs():
+    surface = openmc.Sphere(r=10.0, boundary_type="vacuum")
+    cell = openmc.Cell(region=-surface)
+    model = openmc.Model(openmc.Geometry([cell]))
+
+    with pytest.raises(ValueError):
+        model.plot(n_samples=-1)
+    with pytest.raises(TypeError):
+        model.plot(n_samples=1.5)
+    with pytest.raises(ValueError):
+        model.plot(plane_tolerance=0.0)
+    with pytest.raises(TypeError):
+        model.plot(plane_tolerance='1')
+
+
 def test_model_id_map_initialization(run_in_tmpdir):
     model = openmc.examples.pwr_assembly()
     model.init_lib(output=False)


### PR DESCRIPTION
## Summary

Adds input validation for arguments shared by the plotting methods.

- `n_samples` must be a non-negative int when given and `plane_tolerance` must be strictly positive in `Model.plot`. A tolerance of zero would silently select no source sites since the site filter uses strict inequalities.
- `pixels` must be a positive int, or a sequence of two positive ints. The check lives in `Model._set_plot_defaults`, the one spot shared by `Model.plot`, `Model.id_map` and `Model.slice_data`, so `Geometry.plot`, `Universe.plot`, `Cell.plot`, `Region.plot` and `DAGMCUniverse.plot` are all covered without duplicating the check. Previously a negative scalar produced a `math.sqrt` domain error and a zero or negative tuple entry was passed straight through to the C API.

Note: the oriented-slice (`u_span`/`v_span`) branch of `Model.slice_data` converts `pixels` itself and bypasses `_set_plot_defaults`. A follow-up PR routes that branch through the shared check so the idea can be evaluated separately.

## Checklist

- [x] Unit tests added in `tests/unit_tests/test_model.py` (`test_model_plot_invalid_inputs`)
- [x] Invalid inputs verified to raise `ValueError`/`TypeError` through `Model.plot`, `Cell.plot`, `Region.plot` and `Geometry.plot`
- [x] Valid scalar `pixels` still converts to a per-axis tuple as before