### PR TITLE
Extract shared pixels check and cover slice_data span branch

### DIFF
--- a/docs/source/devguide/contributing.rst
+++ b/docs/source/devguide/contributing.rst
@@ -111,8 +111,8 @@ The TC consists of the following individuals:
 - `Paul Romano <https://github.com/paulromano>`_
 - `Patrick Shriwise <https://github.com/pshriwise>`_
 - `Adam Nelson <https://github.com/nelsonag>`_
-- `Benoit Forget <https://github.com/bforget>`_
 - `Jonathan Shimwell <https://github.com/shimwell>`_
+- `John Tramm <https://github.com/jtramm>`_
 
 The Project Lead is Paul Romano.
 

--- a/openmc/lib/plot.py
+++ b/openmc/lib/plot.py
@@ -87,7 +87,7 @@ _dll.openmc_slice_data.errcheck = _error_handler
 
 
 def slice_data(origin, width=None, basis='xy', u_span=None, v_span=None,
-                pixels=None, show_overlaps=False, level=-1, filter=None,
+                pixels=None, show_overlaps=False, level=None, filter=None,
                 include_properties=True):
     """Generate a 2D raster of geometry and property data for plotting.
 
@@ -111,7 +111,7 @@ def slice_data(origin, width=None, basis='xy', u_span=None, v_span=None,
     show_overlaps : bool, optional
         Whether to detect overlapping cells
     level : int, optional
-        Universe level (-1 for deepest)
+        Universe level (None for deepest)
     filter : openmc.lib.Filter, optional
         Filter for bin index lookup
     include_properties : bool, optional
@@ -127,6 +127,12 @@ def slice_data(origin, width=None, basis='xy', u_span=None, v_span=None,
         Array of shape (v_res, h_res, 2) with float64 dtype containing
         [temperature, density], or None if include_properties=False
     """
+    # Set deepest level as default
+    if level is None:
+        level = -1
+    if not isinstance(level, int):
+        raise TypeError("level must be an integer.")
+
     if pixels is None:
         raise ValueError("pixels must be specified.")
     if len(pixels) != 2:

--- a/openmc/lib/plot.py
+++ b/openmc/lib/plot.py
@@ -265,22 +265,40 @@ _dll.openmc_slice_data_overlap_info.errcheck = _error_handler
 
 
 # Python wrappings for overlap functions
-def slice_data_overlap_count():
+def slice_data_overlap_count() -> int:
+    """Return the number of unique overlaps from the last slice plot.
+
+    Returns
+    -------
+    int
+        Number of unique overlapping cell pairs detected by the most recent
+        :func:`slice_data` call with overlap checking enabled.
+    """
     count = c_size_t()
     _dll.openmc_slice_data_overlap_count(count)
     return count.value
 
 
-def slice_data_overlap_info():
+def slice_data_overlap_info() -> np.ndarray:
+    """Return identifying information for overlaps from the last slice plot.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of shape ``(n, 3)`` with int32 dtype, where ``n`` is the number
+        of unique overlaps detected by the most recent :func:`slice_data` call
+        with overlap checking enabled. Each row contains ``[universe_id,
+        cell1_id, cell2_id]``.
+    """
     n = slice_data_overlap_count()
-    overlap_info = np.empty(n * 3, dtype=np.int32)
+    overlap_info = np.empty((n, 3), dtype=np.int32)
 
     if n > 0:
         _dll.openmc_slice_data_overlap_info(
             n,
             overlap_info.ctypes.data_as(POINTER(c_int32)),
         )
-    return overlap_info, n
+    return overlap_info
 
 
 _dll.openmc_get_plot_index.argtypes = [c_int32, POINTER(c_int32)]

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -21,7 +21,8 @@ import openmc
 import openmc._xml as xml
 from openmc.dummy_comm import DummyCommunicator
 from openmc.executor import _process_CLI_arguments
-from openmc.checkvalue import check_type, check_value, PathLike
+from openmc.checkvalue import (check_type, check_value, check_greater_than,
+                               check_length, PathLike)
 from openmc.exceptions import InvalidIDError
 from openmc.plots import add_plot_params, _BASIS_INDICES, id_map_to_rgb
 from openmc.utility_funcs import change_directory
@@ -1050,6 +1051,13 @@ class Model:
         pixels: int | Sequence[int],
         basis: str
     ):
+        if isinstance(pixels, int):
+            check_greater_than('pixels', pixels, 0)
+        else:
+            check_length('pixels', pixels, 2)
+            for p in pixels:
+                check_greater_than('pixels', p, 0)
+
         x, y, _ = _BASIS_INDICES[basis]
 
         bb = self.bounding_box
@@ -1301,7 +1309,11 @@ class Model:
         import matplotlib.pyplot as plt
 
         check_type('n_samples', n_samples, int | None)
+        if n_samples is not None:
+            check_greater_than('n_samples', n_samples, 0, equality=True)
         check_type('plane_tolerance', plane_tolerance, Real)
+        check_greater_than('plane_tolerance', plane_tolerance, 0.0)
+
         if legend_kwargs is None:
             legend_kwargs = {}
         legend_kwargs.setdefault('bbox_to_anchor', (1.05, 1))

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -22,9 +22,10 @@ import openmc._xml as xml
 from openmc.dummy_comm import DummyCommunicator
 from openmc.executor import _process_CLI_arguments
 from openmc.checkvalue import (check_type, check_value, check_greater_than,
-                               check_length, PathLike)
+                               PathLike)
 from openmc.exceptions import InvalidIDError
-from openmc.plots import add_plot_params, _BASIS_INDICES, id_map_to_rgb
+from openmc.plots import (add_plot_params, _check_pixels, _BASIS_INDICES,
+                          id_map_to_rgb)
 from openmc.utility_funcs import change_directory
 
 
@@ -1051,12 +1052,7 @@ class Model:
         pixels: int | Sequence[int],
         basis: str
     ):
-        if isinstance(pixels, int):
-            check_greater_than('pixels', pixels, 0)
-        else:
-            check_length('pixels', pixels, 2)
-            for p in pixels:
-                check_greater_than('pixels', p, 0)
+        _check_pixels(pixels)
 
         x, y, _ = _BASIS_INDICES[basis]
 
@@ -1218,6 +1214,8 @@ class Model:
             Shape (v_res, h_res, 2) float64 array with [temperature, density],
             or None if include_properties=False.
         """
+        _check_pixels(pixels)
+
         import openmc.lib
 
         if width is not None and (u_span is not None or v_span is not None):

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -262,6 +262,16 @@ def add_plot_params(func):
     return func
 
 
+def _check_pixels(pixels):
+    """Check that pixels is a positive int or a pair of positive ints."""
+    if isinstance(pixels, int):
+        cv.check_greater_than('pixels', pixels, 0)
+    else:
+        cv.check_length('pixels', pixels, 2)
+        for p in pixels:
+            cv.check_greater_than('pixels', p, 0)
+
+
 def _get_plot_image(plot, cwd):
     from IPython.display import Image
 

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -88,10 +88,7 @@ void PropertyData::set_value(size_t y, size_t x, const Particle& p, int level,
 {
   Cell* c = model::cells.at(p.lowest_coord().cell()).get();
   data_(y, x, 0) = (p.sqrtkT() * p.sqrtkT()) / K_BOLTZMANN;
-  if (c->type_ != Fill::UNIVERSE && p.material() != MATERIAL_VOID) {
-    Material* m = model::materials.at(p.material()).get();
-    data_(y, x, 1) = m->density_gpcc_;
-  }
+  data_(y, x, 1) = c->density(p.cell_instance());
 }
 
 void PropertyData::set_overlap(size_t y, size_t x, int /*overlap_idx*/)
@@ -150,7 +147,7 @@ void RasterData::set_value(size_t y, size_t x, const Particle& p, int level,
   // set density (g/cm³)
   if (c->type_ != Fill::UNIVERSE && p.material() != MATERIAL_VOID) {
     Material* m = model::materials.at(p.material()).get();
-    property_data_(y, x, 1) = m->density_gpcc_;
+    property_data_(y, x, 1) = c->density(p.cell_instance());
   }
 }
 

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -156,12 +156,12 @@ void RasterData::set_value(size_t y, size_t x, const Particle& p, int level,
 
 void RasterData::set_overlap(size_t y, size_t x, int overlap_idx)
 {
-  // Set cell, instance, and material to OVERLAP, but preserve filter bin
-  id_data_(y, x, 0) = OVERLAP;
+  // Set cell, instance, and material to OVERLAP, but preserve filter bin for
+  // tally plotting. Cell encodes the overlap index as a negative number so that
+  // it can be used to look up overlap information in the plotter.
+  id_data_(y, x, 0) = OVERLAP - overlap_idx - 1;
   id_data_(y, x, 1) = OVERLAP;
-  id_data_(y, x, 2) = OVERLAP - overlap_idx - 1;
-  // Note: id_data_(y, x, 3) is NOT overwritten - preserves filter bin for tally
-  // plotting
+  id_data_(y, x, 2) = OVERLAP;
 
   property_data_(y, x, 0) = OVERLAP;
   property_data_(y, x, 1) = OVERLAP;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1247,6 +1247,7 @@ void read_settings_xml(pugi::xml_node root)
   // read weight windows from file
   if (check_for_node(root, "weight_windows_file")) {
     weight_windows_file = get_node_value(root, "weight_windows_file");
+    weight_windows_on = true;
   }
 
   // read settings for weight windows value, this will override

--- a/tests/unit_tests/test_lib.py
+++ b/tests/unit_tests/test_lib.py
@@ -926,6 +926,22 @@ def test_property_map(lib_init):
     assert np.allclose(expected_properties, properties, atol=1e-04)
 
 
+def test_slice_data(lib_init):
+    expected_properties = np.array(
+        [[(293.6, 0.740582), (293.6, 6.55), (293.6, 0.740582)],
+         [ (293.6, 6.55), (293.6, 10.29769),  (293.6, 6.55)],
+         [(293.6, 0.740582), (293.6, 6.55), (293.6, 0.740582)]], dtype='float')
+    origin = (0.0, 0.0, 0.0)
+    _, properties = openmc.lib.slice_data(
+        origin,
+        width=(1.26, 1.26),
+        basis='xy',
+        pixels=(3, 3),
+        include_properties=True
+    )
+    assert np.allclose(expected_properties, properties, atol=1e-04)
+
+
 def test_solid_raytrace_plot(lib_init, pincell_model):
     # Ensure plot mapping can be accessed and grows after allocation
     n0 = len(openmc.lib.plots)

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -679,6 +679,8 @@ def test_model_plot_invalid_inputs():
         model.plot(pixels=(0, 100))
     with pytest.raises(ValueError):
         model.plot(pixels=(100,))
+    with pytest.raises(ValueError):
+        model.slice_data(u_span=(2, 0, 0), v_span=(0, 2, 0), pixels=-1)
 
 
 def test_model_id_map_initialization(run_in_tmpdir):

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -660,6 +660,27 @@ def test_model_plot():
     plt.close('all')
 
 
+def test_model_plot_invalid_inputs():
+    surface = openmc.Sphere(r=10.0, boundary_type="vacuum")
+    cell = openmc.Cell(region=-surface)
+    model = openmc.Model(openmc.Geometry([cell]))
+
+    with pytest.raises(ValueError):
+        model.plot(n_samples=-1)
+    with pytest.raises(TypeError):
+        model.plot(n_samples=1.5)
+    with pytest.raises(ValueError):
+        model.plot(plane_tolerance=0.0)
+    with pytest.raises(TypeError):
+        model.plot(plane_tolerance='1')
+    with pytest.raises(ValueError):
+        model.plot(pixels=-1)
+    with pytest.raises(ValueError):
+        model.plot(pixels=(0, 100))
+    with pytest.raises(ValueError):
+        model.plot(pixels=(100,))
+
+
 def test_model_id_map_initialization(run_in_tmpdir):
     model = openmc.examples.pwr_assembly()
     model.init_lib(output=False)

--- a/tests/unit_tests/test_slice_data_overlap_info.py
+++ b/tests/unit_tests/test_slice_data_overlap_info.py
@@ -55,12 +55,13 @@ def test_overlaps_enabled(overlap_model):
     # Run a single slice with overlap detection enabled and check all
     # expected properties in one pass.
     geom_data = run_slice()
-    overlap_info, n = openmc.lib.slice_data_overlap_info()
-    mat_ids = geom_data[:, :, 2]
+    overlap_info = openmc.lib.slice_data_overlap_info()
+    n = overlap_info.shape[0]
+    cell_ids = geom_data[:, :, 0]
 
-    # mat_ids should contain values more negative than _OVERLAP; RasterData
+    # cell_ids should contain values more negative than _OVERLAP; RasterData
     # encodes each unique overlap as OVERLAP - overlap_idx - 1 into slot 2.
-    assert np.any(mat_ids < _OVERLAP)
+    assert np.any(cell_ids < _OVERLAP)
 
     # overlap_keys should have 2 entries for the two distinct overlapping
     # cylinder pairs in this model.
@@ -68,9 +69,9 @@ def test_overlaps_enabled(overlap_model):
 
     # Each entry is a (universe_id, cell1_id, cell2_id) triple; verify values.
     for i in range(n):
-        universe_id = int(overlap_info[i * 3])
-        cell1_id = int(overlap_info[i * 3 + 1])
-        cell2_id = int(overlap_info[i * 3 + 2])
+        universe_id = int(overlap_info[i, 0])
+        cell1_id = int(overlap_info[i, 1])
+        cell2_id = int(overlap_info[i, 2])
         assert universe_id == 1
         assert cell1_id in {1, 2, 3}
         assert cell2_id in {1, 2, 3}
@@ -81,7 +82,8 @@ def test_overlaps_disabled(overlap_model):
     # With show_overlaps=False, set_overlap is never called and overlap_keys
     # is never written to, so the image and map should both be clean.
     geom_data = run_slice(show_overlaps=False)
-    _, n = openmc.lib.slice_data_overlap_info()
+    overlap_info = openmc.lib.slice_data_overlap_info()
+    n = overlap_info.shape[0]
 
     assert not np.any(geom_data[:, :, 2] < _OVERLAP)
     assert n == 0


### PR DESCRIPTION
## Summary

Follow-up to #124, based on that branch so only the incremental diff shows here.

- Extracts the `pixels` validation from `Model._set_plot_defaults` into a `_check_pixels` helper in `openmc/plots.py`, next to `add_plot_params`.
- Calls the helper at the top of `Model.slice_data`, which covers the oriented-slice (`u_span`/`v_span`) branch that converts `pixels` itself and never reaches `_set_plot_defaults`. The call sits before the `openmc.lib` import so invalid arguments raise without needing the compiled core.
- `_set_plot_defaults` keeps its check via the helper, so `Model.plot` remains validated even though it reaches `slice_data` later.

## Checklist

- [x] Unit test added for the span branch (`Model.slice_data(u_span=..., v_span=..., pixels=-1)` raises `ValueError`)
- [x] All entry points re-verified (`Model.plot`, `Cell.plot`, `Region.plot`, `Geometry.plot`, `Model.slice_data` span branch); valid scalar `pixels` still converts to a per-axis tuple