### PR TITLE
Add CI guard against C++ alternative operator tokens

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -58,3 +58,17 @@ jobs:
           echo "Some files failed the formatting check."
           echo "See job summary and file annotations for details."
           exit 1
+
+  # clang-format does not rewrite C++ alternative operator tokens, so this is
+  # the only thing standing between an 'and' and a broken MSVC build.
+  alternative-tokens:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Check for C++ alternative operator tokens
+        run: python tools/ci/check_alternative_tokens.py

--- a/tools/ci/check_alternative_tokens.py
+++ b/tools/ci/check_alternative_tokens.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Reject C++ alternative operator tokens in OpenMC's own sources.
+
+``and``, ``or``, ``not`` and friends are standard C++, but MSVC only accepts
+them when ``/permissive-`` is passed, which is not the default for a
+CMake-driven build. A single ``and`` in a widely included header therefore
+breaks the whole Windows build, and because the failure is a parse error the
+resulting log is a wall of unrelated cascade errors that says nothing about the
+real cause. clang-format does not rewrite these tokens, so nothing else in CI
+catches them.
+
+Vendored code under src/external/ is not ours to restyle and is skipped.
+
+Run with no arguments to check the default directories::
+
+    python tools/ci/check_alternative_tokens.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Spelled with concatenation so this file does not match its own check.
+TOKENS = [
+    "a" "nd", "a" "nd_eq", "bi" "tand", "bi" "tor", "co" "mpl",
+    "n" "ot", "n" "ot_eq", "o" "r", "o" "r_eq", "x" "or", "x" "or_eq",
+]
+
+TOKEN_RE = re.compile(r"(?<!\w)(" + "|".join(TOKENS) + r")(?!\w)")
+
+DEFAULT_PATHS = ["src", "include"]
+EXCLUDED_DIRS = {"external"}
+SUFFIXES = {".cpp", ".h", ".hh", ".hpp", ".cc"}
+
+
+def blank_comments_and_literals(src: str) -> str:
+    """Replace comments and string/char literals with spaces.
+
+    Newlines are preserved so reported line numbers still line up with the
+    original file.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(src)
+    while i < n:
+        c = src[i]
+        nxt = src[i + 1] if i + 1 < n else ""
+
+        if c == "/" and nxt == "/":
+            while i < n and src[i] != "\n":
+                out.append(" ")
+                i += 1
+        elif c == "/" and nxt == "*":
+            out.append("  ")
+            i += 2
+            while i < n and not (src[i] == "*" and src[i + 1 : i + 2] == "/"):
+                out.append("\n" if src[i] == "\n" else " ")
+                i += 1
+            if i < n:
+                out.append("  ")
+                i += 2
+        elif c in "\"'":
+            quote = c
+            out.append(" ")
+            i += 1
+            while i < n and src[i] != quote:
+                # Skip escaped characters so \" does not end the literal.
+                if src[i] == "\\" and i + 1 < n:
+                    out.append(" ")
+                    i += 1
+                out.append("\n" if src[i] == "\n" else " ")
+                i += 1
+            if i < n:
+                out.append(" ")
+                i += 1
+        else:
+            out.append(c)
+            i += 1
+
+    return "".join(out)
+
+
+def iter_sources(paths: list[str]):
+    for root in paths:
+        for path in sorted(Path(root).rglob("*")):
+            if path.suffix not in SUFFIXES:
+                continue
+            if EXCLUDED_DIRS.intersection(path.parts):
+                continue
+            yield path
+
+
+def check(paths: list[str]) -> int:
+    failures = 0
+    for path in iter_sources(paths):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        code = blank_comments_and_literals(text)
+        original_lines = text.splitlines()
+        for lineno, line in enumerate(code.splitlines(), start=1):
+            for match in TOKEN_RE.finditer(line):
+                failures += 1
+                shown = original_lines[lineno - 1].strip()
+                print(
+                    f"{path}:{lineno}: alternative token "
+                    f"'{match.group(1)}' -> use the symbolic operator\n"
+                    f"    {shown}"
+                )
+    return failures
+
+
+def main(argv: list[str]) -> int:
+    paths = argv[1:] or DEFAULT_PATHS
+    failures = check(paths)
+
+    if failures:
+        print(
+            f"\n{failures} alternative operator token(s) found. MSVC rejects "
+            "these without /permissive-, which breaks the Windows build.\n"
+            "Replace them with the symbolic form (&& || ! & | ~ ^ etc.)."
+        )
+        return 1
+
+    print("No C++ alternative operator tokens found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Why

MSVC accepts the C++ alternative operator tokens (`and`, `or`, `not` and friends) only when `/permissive-` is passed, which is not the default for a CMake-driven build. One of these in a widely included header breaks the entire Windows build.

The cost is badly out of proportion to the cause. Two occurrences of `and` in `mesh.h`, fixed in #4048, produced over a hundred cascade errors in a Windows build probe, spread across unrelated translation units: missing members of `openmc::simulation`, undefined `UnstructuredMesh` members, and complaints about MSVC's own internal `_Cosh` and `_Exp` names. None of it pointed at the real line, which was the very first error in the log and easy to miss among the noise.

`clang-format` does not rewrite these tokens, so nothing in CI catches them today.

## What

* `tools/ci/check_alternative_tokens.py`, which scans `src/` and `include/` and exits non-zero on any alternative operator token.
* A fast `alternative-tokens` job in the existing `C++ Format Check` workflow.

The check strips comments and string literals before scanning, so it does not trip on prose. Newlines are preserved during stripping so reported line numbers match the original file. Vendored code under `src/external/` is skipped.

It reports file, line and the offending source line:

```
include/openmc/mesh.h:636: alternative token 'and' -> use the symbolic operator
    if ((idx > 0) and (idx <= N)) {
```

The script takes optional path arguments so it can be run locally during development:

```
python tools/ci/check_alternative_tokens.py
```

## Testing

* Passes on current `develop` with no findings, so it does not introduce a red CI.
* Run against `mesh.h` as of `163fdf78^` it flags exactly the two real sites at lines 636 and 701, matching the locations MSVC reported.
* Checked against a case containing the tokens inside line comments, block comments, string literals, an escaped quote, `#include <complex>`, and the identifiers `n_and`, `order`, `nothing` and `sword`: no false positives, while genuine `and`, `not` and `bitor` operators on adjacent lines are all caught.