### PR TITLE
Give run_mode and rel_max_lost_particles C linkage

### DIFF
--- a/include/openmc/settings.h
+++ b/include/openmc/settings.h
@@ -126,7 +126,7 @@ extern "C" const char* path_statepoint_c; //!< C pointer to statepoint file name
 
 extern "C" int32_t n_inactive;         //!< number of inactive batches
 extern "C" int32_t max_lost_particles; //!< maximum number of lost particles
-extern double
+extern "C" double
   rel_max_lost_particles; //!< maximum number of lost particles, relative to the
                           //!< total number of particles
 extern "C" int32_t
@@ -160,7 +160,7 @@ extern double res_scat_energy_min; //!< Min energy in [eV] for res. upscattering
 extern double res_scat_energy_max; //!< Max energy in [eV] for res. upscattering
 extern vector<std::string>
   res_scat_nuclides;           //!< Nuclides using res. upscattering treatment
-extern RunMode run_mode;       //!< Run mode (eigenvalue, fixed src, etc.)
+extern "C" RunMode run_mode;   //!< Run mode (eigenvalue, fixed src, etc.)
 extern SolverType solver_type; //!< Solver Type (Monte Carlo or Random Ray)
 extern std::unordered_set<int>
   sourcepoint_batch; //!< Batches when source should be written


### PR DESCRIPTION
## The bug

`openmc.lib` reads both of these globals through ctypes `in_dll` under their plain names, but both are declared in `namespace openmc::settings` without `extern "C"`, so the symbols are name-mangled and the lookup has never resolved.

On a Linux build of current `develop`:

```python
>>> ctypes.c_int.in_dll(dll, 'run_mode')
ValueError: openmc/lib/libopenmc.so: undefined symbol: run_mode
```

`nm` shows why:

```
_ZN6openmc8settings8run_modeE
_ZN6openmc8settings22rel_max_lost_particlesE
```

So `openmc.lib.settings.run_mode` raises through its property getter, and `openmc.lib.settings.rel_max_lost_particles` raises through the `_DLLGlobal` descriptor in `openmc/lib/core.py`.

**This is not platform specific.** The symbols are mangled on Linux, macOS and Windows alike. It surfaced while auditing data exports for a Windows DLL build, but it is not a Windows problem.

## Why it is a two-token fix

Every other global in `settings.h` that `openmc.lib` reads is already `extern "C"`, including `max_lost_particles` on the line immediately above:

```cpp
extern "C" int32_t max_lost_particles; //!< maximum number of lost particles
extern double
  rel_max_lost_particles; //!< maximum number of lost particles, relative to ...
```

`rel_max_lost_particles` has been broken since it was introduced. d763806c4 renamed it from `relative_max_lost_particles` on both the C++ and Python sides specifically to make the names match, but without `extern "C"` the symbol never matched under either spelling.

`solver_type` is deliberately left alone, since `openmc.lib` does not read it.

## Verification

Built locally and confirmed both directions.

Before, the mangled forms are present and the plain names are absent. After:

```
nm:      B run_mode                     D rel_max_lost_particles
ctypes:  run_mode = 0                   (RunMode::UNSET)
         rel_max_lost_particles = 1e-06
```

`1e-06` matches the `double rel_max_lost_particles {1.0e-6}` default at `settings.cpp:105`, so the symbols resolve to the right storage rather than to something arbitrary. The mangled forms are gone, and the full build including `openmc.exe` links clean, so nothing in the tree depended on the old mangled names.

## Note on test coverage

No test is included here. Nothing currently exercises either attribute, which is why this went unnoticed for years: the matches for `run_mode` under `tests/` are all either `openmc.Settings` (the XML layer) or direct C++ access in `test_ray.cpp`, and `openmc/cmfd.py` reads several `openmc.lib.settings` attributes but not these two. A regression test in `tests/unit_tests/test_lib.py` would be worth adding so this cannot silently rot again.